### PR TITLE
adding new bidders from 0.34.1 thru 1.4.0

### DIFF
--- a/bidderPatterns.js
+++ b/bidderPatterns.js
@@ -350,10 +350,10 @@ var bidderPatterns = {
     'ads.stickyadstv.com/www/delivery/swfIndex.php'
   ],
   'IQM': [
-    'pbd.bids.iqm.com'
+    'pbd.bids.iqm.com/'
   ],
   'Rxrtb': [
-    'bid.rxrtb.bid'
+    'bid.rxrtb.bid/'
   ],
   'ServerBid Server': [
     'e.serverbid.com/api/v2'
@@ -362,7 +362,7 @@ var bidderPatterns = {
     'gjc.gjirafa.com/Home/GetBid'
   ],
   'Nasmedia Admixer': [
-    'adn.admixer.co.kr:10443/prebid'
+    'adn.admixer.co.kr/prebid'
   ],
   'Media.net': [
     'prebid.media.net/rtb/prebid'
@@ -383,10 +383,10 @@ var bidderPatterns = {
     'tas.rockyou.net/servlet/rotator/'
   ],
   'Vidazoo': [
-    'prebid.cliipa.com'
+    'prebid.cliipa.com/'
   ],
   'Yieldlab': [
-    'ad.yieldlab.net'
+    'ad.yieldlab.net/'
   ],
   'Adgeneration': [
     'd.socdm.com/adsv/v1',
@@ -396,7 +396,7 @@ var bidderPatterns = {
     'ads.danmarketplace.com/hb'
   ],
   'Xendiz': [
-    'prebid.xendiz.com'
+    'prebid.xendiz.com/'
   ],
   'Peak226': [
     'a.ad216.com/header_bid'
@@ -405,6 +405,6 @@ var bidderPatterns = {
     'pixel.adsafeprotected.com/services/pub'
   ],
   'Gamma SSP': [
-    'hb.gammaplatform.com'
+    'hb.gammaplatform.com/'
   ]
 };

--- a/bidderPatterns.js
+++ b/bidderPatterns.js
@@ -249,7 +249,8 @@ var bidderPatterns = {
     'krk.kargo.com/api/v1/bid'
   ],
   'C1X': [
-    'ht-integration.c1exchange.com/ht'
+    'ht-integration.c1exchange.com/ht',
+    'ht.c1exchange.com/ht'
   ],
   'MobFox': [
     'my.mobfox.com/request.php'
@@ -339,4 +340,71 @@ var bidderPatterns = {
   'Undertone': [
     'hb.undertone.com/hb'
   ],
+  'Readpeak': [
+    'app.readpeak.com/header/prebid'
+  ],
+  'Yieldone': [
+    'y.one.impact-ad.jp/h_bid'
+  ],
+  'FreeWheel': [
+    'ads.stickyadstv.com/www/delivery/swfIndex.php'
+  ],
+  'IQM': [
+    'pbd.bids.iqm.com'
+  ],
+  'Rxrtb': [
+    'bid.rxrtb.bid'
+  ],
+  'ServerBid Server': [
+    'e.serverbid.com/api/v2'
+  ],
+  'Gjirafa': [
+    'gjc.gjirafa.com/Home/GetBid'
+  ],
+  'Nasmedia Admixer': [
+    'adn.admixer.co.kr:10443/prebid'
+  ],
+  'Media.net': [
+    'prebid.media.net/rtb/prebid'
+  ],
+  'Vi': [
+    'pb.vi-serve.com/prebid/bid'
+  ],
+  'InSkin': [
+    'mfad.inskinad.com/api/v2'
+  ],
+  'Colossus SSP': [
+    'colossusssp.com/?c=o&m=multi'
+  ],
+  'Optimera': [
+    's3.amazonaws.com/elasticbeanstalk-us-east-1-397719490216/json/client/'
+  ],
+  'RockYou': [
+    'tas.rockyou.net/servlet/rotator/'
+  ],
+  'Vidazoo': [
+    'prebid.cliipa.com'
+  ],
+  'Yieldlab': [
+    'ad.yieldlab.net'
+  ],
+  'Adgeneration': [
+    'd.socdm.com/adsv/v1',
+    'api-test.scaleout.jp/adsv/v1'
+  ],
+  'Dentsu Aegis Network Marketplace': [
+    'ads.danmarketplace.com/hb'
+  ],
+  'Xendiz': [
+    'prebid.xendiz.com'
+  ],
+  'Peak226': [
+    'a.ad216.com/header_bid'
+  ],
+  'IAS': [
+    'pixel.adsafeprotected.com/services/pub'
+  ],
+  'Gamma SSP': [
+    'hb.gammaplatform.com'
+  ]
 };


### PR DESCRIPTION
Updating the list of new bidder adapters between prebid.js releases 0.34.1 thru 1.4.0.