### PR TITLE
Smart url and name updated

### DIFF
--- a/bidderPatterns.js
+++ b/bidderPatterns.js
@@ -74,8 +74,8 @@ var bidderPatterns = {
   'Mantis': [
     'mantodea.mantisadnetwork.com/'
   ],
-  'SmartRTB+': [
-    'prg.smartadserver.com/prebid'
+  'Smart': [
+    '.smartadserver.com/prebid'
   ],
   'RhythmOne': [
     'tag.1rx.io/rmp/*/*/mvo'


### PR DESCRIPTION
* prg. prefix removed from the url to match all possible sub-domains 
* SmartRTB+ renamed to Smart to match the company brand