### PR TITLE
Updating pattern for Ad4Game

### DIFF
--- a/bidderPatterns.js
+++ b/bidderPatterns.js
@@ -314,7 +314,7 @@ var bidderPatterns = {
     '.adocean.pl/ad.json'
   ],
   'Ad4Game': [
-    'ads.ad4game.com/v1/bid'
+    '.ad4game.com/v1/bid'
   ],
   'AdKernelAdn': [
     'tag.adkernel.com/',


### PR DESCRIPTION
Doesn't show for testing mode. 
Example url which doesn't show 'http://dev01.ad4game.com/v1/bid'.