### PR TITLE
add openx pattern for video delivery

### DIFF
--- a/bidderPatterns.js
+++ b/bidderPatterns.js
@@ -6,7 +6,8 @@ var bidderPatterns = {
   'Openx': [
     '.servedbyopenx.com/w/1.0/acj',
     '.openx.net/w/1.0/acj',
-    '.openx.net/w/1.0/arj'
+    '.openx.net/w/1.0/arj',
+    '.openx.net/v/1.0/avjp'
   ],
   'Pubmatic': [
     '.pubmatic.com/AdServer/AdCallAggregator',


### PR DESCRIPTION
## Background

- [x] adds support for openx video delivery pattern `'.openx.net/v/1.0/avjp'` 

## Test Plan

👀 the openx video adapter code here https://github.com/prebid/Prebid.js/blob/3f5bcf2af251f9d85af33f274e69027822c90399/modules/openxBidAdapter.js#L301-L302 
The url contains `v/1.0/avjp`. 