### PR TITLE
Update Criteo endpoint

### DIFF
--- a/bidderPatterns.js
+++ b/bidderPatterns.js
@@ -190,7 +190,7 @@ var bidderPatterns = {
   ],
   'Criteo': [
     '.criteo.com/delivery/rta/rta.js',
-    'bidder.criteo.com/'
+    'bidder.criteo.com/cdb'
   ],
   'DecenterAds': [
     'supply.decenterads.com/'


### PR DESCRIPTION
Right now its matching request that are not part of bidding, which ends invilid timing measurement